### PR TITLE
Fix PlaceAutocompleteAdapter data modification from background thread

### DIFF
--- a/PlaceCompleteAdapter/Application/src/main/java/com/example/google/playservices/placecomplete/PlaceAutocompleteAdapter.java
+++ b/PlaceCompleteAdapter/Application/src/main/java/com/example/google/playservices/placecomplete/PlaceAutocompleteAdapter.java
@@ -141,23 +141,31 @@ public class PlaceAutocompleteAdapter
             @Override
             protected FilterResults performFiltering(CharSequence constraint) {
                 FilterResults results = new FilterResults();
+                // this method call in background thread, so use different list to hold the data
+                ArrayList<AutocompletePrediction> filterData = new ArrayList<>();
+
                 // Skip the autocomplete query if no constraints are given.
                 if (constraint != null) {
                     // Query the autocomplete API for the (constraint) search string.
-                    mResultList = getAutocomplete(constraint);
-                    if (mResultList != null) {
-                        // The API successfully returned results.
-                        results.values = mResultList;
-                        results.count = mResultList.size();
-                    }
+                    filterData = getAutocomplete(constraint);
                 }
+
+                results.values = filterData;
+                if (filterData != null) {
+                    results.count = filterData.size();
+                } else {
+                    results.count = 0;
+                }
+               
                 return results;
             }
 
             @Override
             protected void publishResults(CharSequence constraint, FilterResults results) {
+				
                 if (results != null && results.count > 0) {
                     // The API returned at least one result, update the data.
+                    mResultList = (ArrayList<AutocompletePrediction>) results.values;
                     notifyDataSetChanged();
                 } else {
                     // The API did not return any results, invalidate the data set.


### PR DESCRIPTION
Filter (`protected FilterResults performFiltering()`) is modifying the data in background, it crashed when `getItem()` is accessed from UI-thread. Following error also generate when `publishResults` invoked.

> Fatal Exception: java.lang.IllegalStateException: The content of the adapter has changed but ListView did not receive a notification. Make sure the content of your adapter is not modified from a background thread, but only from the UI thread. Make sure your adapter calls notifyDataSetChanged() when its content changes. [in ListView(-1, class android.widget.ListPopupWindow$DropDownListView) with Adapter

The sample code is not correct and it rise these (#23, #27) expected issues when integrate in application. 

Fix #27, #23 
